### PR TITLE
helm repo overwrite fix

### DIFF
--- a/installers/linux/engine/scripts/dh2helm.py
+++ b/installers/linux/engine/scripts/dh2helm.py
@@ -363,10 +363,14 @@ def main():
         if ('helmrepouser' in newvals):
             mylogin = mylogin + "--username " + newvals['helmrepouser'] + " "
 
-        if ('helmrepopass' in newvals):
+		if ('helmrepopass' in newvals):
             mylogin = mylogin + "--password " + newvals['helmrepopass'] + " "
-
-        runcmd(fp_task, to_dir, helm_exe + ' repo add ' + mylogin + newvals['helmrepo']['name'] + " " + newvals['helmrepo']['url'])
+			
+		if (helm_exe.lower() == "helm2"):
+			runcmd(fp_task, to_dir, helm_exe + ' repo add ' + mylogin + newvals['helmrepo']['name'] + " " + newvals['helmrepo']['url'])
+		else:
+			runcmd(fp_task, to_dir, helm_exe + ' repo add --force-update ' + mylogin + newvals['helmrepo']['name'] + " " + newvals['helmrepo']['url'])
+        # runcmd(fp_task, to_dir, helm_exe + ' repo add ' + mylogin + newvals['helmrepo']['name'] + " " + newvals['helmrepo']['url'])
         runcmd(fp_task, to_dir, helm_exe + ' repo update')
 
     version = newvals.get('chartversion', 'latest')

--- a/installers/linux/engine/scripts/dh2helm.py
+++ b/installers/linux/engine/scripts/dh2helm.py
@@ -363,13 +363,13 @@ def main():
         if ('helmrepouser' in newvals):
             mylogin = mylogin + "--username " + newvals['helmrepouser'] + " "
 
-		if ('helmrepopass' in newvals):
+        if ('helmrepopass' in newvals):
             mylogin = mylogin + "--password " + newvals['helmrepopass'] + " "
-			
-		if (helm_exe.lower() == "helm2"):
-			runcmd(fp_task, to_dir, helm_exe + ' repo add ' + mylogin + newvals['helmrepo']['name'] + " " + newvals['helmrepo']['url'])
-		else:
-			runcmd(fp_task, to_dir, helm_exe + ' repo add --force-update ' + mylogin + newvals['helmrepo']['name'] + " " + newvals['helmrepo']['url'])
+
+        if (helm_exe.lower() == "helm2"):
+            runcmd(fp_task, to_dir, helm_exe + ' repo add ' + mylogin + newvals['helmrepo']['name'] + " " + newvals['helmrepo']['url'])
+        else:
+            runcmd(fp_task, to_dir, helm_exe + ' repo add --force-update ' + mylogin + newvals['helmrepo']['name'] + " " + newvals['helmrepo']['url'])
         # runcmd(fp_task, to_dir, helm_exe + ' repo add ' + mylogin + newvals['helmrepo']['name'] + " " + newvals['helmrepo']['url'])
         runcmd(fp_task, to_dir, helm_exe + ' repo update')
 

--- a/installers/linux/engine/scripts/helm-image-digest.sh
+++ b/installers/linux/engine/scripts/helm-image-digest.sh
@@ -36,7 +36,7 @@ if [ "$chartorg" == "" ]; then
 fi
 
 # Add Helm Repo
-$helmexe repo add $helmlogin $helmrepo $helmrepourl 2>&1 1>/dev/null
+$helmexe repo add --force-update $helmlogin $helmrepo $helmrepourl 2>&1 1>/dev/null
 
 # Get latest Helm Charts
 $helmexe repo update 2>&1 1>/dev/null

--- a/installers/linux/engine/scripts/helminfo.sh
+++ b/installers/linux/engine/scripts/helminfo.sh
@@ -26,7 +26,7 @@ if [ "$chartvalues" != "" ]; then
   override_values="-f $chartvalues"
 fi
 
-echo $helmlogin $helmrepo $helmrepourl | xargs $helmexe repo add  2>&1 1>/dev/null
+echo $helmlogin $helmrepo $helmrepourl | xargs $helmexe repo add --force-update  2>&1 1>/dev/null
 $helmexe repo update 2>&1 1>/dev/null
 $helmexe fetch $chartorg/$chartname --version $chartversion 2>&1 1>/dev/null
 digest=`sha256sum $chartname*.tgz | cut -f1 -d " "`


### PR DESCRIPTION
As of Helm v3.3.2, `helm repo add` command will not overwrite the existing repo entry. This creates an issue if there is an update to the Helm repo URL or credentials.
Adding `--force-update` flag fixes this issue.
ref: https://github.com/helm/helm/releases/tag/v3.3.2