### PR TITLE
Added a procedure meant for installing helm plugins

### DIFF
--- a/installers/linux/engine/scripts/installhelmplugin.sh
+++ b/installers/linux/engine/scripts/installhelmplugin.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+helm plugin install $1 --version $2

--- a/procedures/InstallHelmPlugin.re
+++ b/procedures/InstallHelmPlugin.re
@@ -1,0 +1,13 @@
+<!-- Release Engineer Export File -->
+<action name="InstallHelmPlugin" summary="Installs a single helm plugin" isGraphical="N" category="General">
+<kind copy="N">2</kind>
+<cmdline>
+<script name="$DMHOME/scripts/installhelmplugin.sh" />
+<argument name="PluginUrl" type="entry" inpos="1" switchmode="S" switch="" negswitch="" pad="false" required="true" />
+<argument name="PluginVersion" type="entry" inpos="2" switchmode="S" switch="" negswitch="" pad="false" required="true" />
+</cmdline>
+<fragment name="InstallHelmPlugin" summary="">
+<parameter name="PluginUrl" type="entry" required="Y"/>
+<parameter name="PluginVersion" type="entry" required="Y"/>
+</fragment>
+</action>


### PR DESCRIPTION
Sometimes applications can rely on different helm plugin in order to perform their deployment. The helm 'secrets' plugin for example (https://github.com/jkroepke/helm-secrets) can be used to decrypt a values.yaml that contains sensitive data at deploy time. Helm doesn't have that capability by itself. This procedure enables users to add a desired helm plugin with its corresponding version to the ortelius container.